### PR TITLE
Correct the typo in Chapter 6

### DIFF
--- a/classes/README.md
+++ b/classes/README.md
@@ -72,7 +72,7 @@ class Person
     @@people_count += 1
   end
 
-  def number_of_instances
+  def self.number_of_instances
     return @@people_count
   end
 end


### PR DESCRIPTION
There was a typo in chapter about classes.
The #number_of_instances should be a class, not instance method.