### PR TITLE
Fix array syntax example

### DIFF
--- a/arrays,_hashes,_and_blocks/arrays.md
+++ b/arrays,_hashes,_and_blocks/arrays.md
@@ -29,7 +29,7 @@ Adding to an array can be done in two ways: The first looks like this: `example_
 
 ### Iterating over Arrays:
 
-Iterating over arrays uses syntax that looks like this: `example_array { |i| puts i }`
+Iterating over arrays uses syntax that looks like this: `example_array.each { |i| puts i }`
 
 Iterating over multi-dimensional arrays is a little bit different:
 


### PR DESCRIPTION
In the example that shows the syntax for iterating over an array, the `each` method was not included. I simply added it in.